### PR TITLE
8315809: Fix copyright lines in jfx-tests repo after JDK-8315409

### DIFF
--- a/bigapps/SceneBuilderTest/src/scenebuilder/RunGUIBrowser.java
+++ b/bigapps/SceneBuilderTest/src/scenebuilder/RunGUIBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ColorHelper.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ColorHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/AbstractPropertyValueSetter.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/AbstractPropertyValueSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/NumberPropertyValueSetter.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/NumberPropertyValueSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/PropertiesTable.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/PropertiesTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/PropertyTablesFactory.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/PropertyTablesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/PropertyValueListener.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/PropertyValueListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/SpecialTablePropertiesProvider.java
+++ b/functional/ControlsTests/src/javafx/scene/control/test/utils/ptables/SpecialTablePropertiesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/commons/ControlsTest.java
+++ b/functional/ControlsTests/test/javafx/commons/ControlsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/ClipboardTest.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/ClipboardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/DragDropWithControlsTest.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/DragDropWithControlsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/DragEventOneStageTest.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/DragEventOneStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/DragEventTwoStageTest.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/DragEventTwoStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/DragboardTest.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/DragboardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/ExtendedDragTest.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/ExtendedDragTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/draganddrop/TestBase.java
+++ b/functional/ControlsTests/test/javafx/draganddrop/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/ListView/ListViewAddRemoveTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/ListView/ListViewAddRemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/ListView/NewListViewTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/ListView/NewListViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/ListView/TestBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/ListView/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/Mnemonics/LabelsMnemonicsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/Mnemonics/LabelsMnemonicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/Mnemonics/MnemonicsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/Mnemonics/MnemonicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/ScrollPane/ScrollPaneTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/ScrollPane/ScrollPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/ToolBar/ToolBarBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/ToolBar/ToolBarBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/cell/CellsTestBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/cell/CellsTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/cell/CheckBoxTreeItemTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/cell/CheckBoxTreeItemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/cell/TableCellsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/cell/TableCellsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/cell/TreeTableCellsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/cell/TreeTableCellsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/AxisBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/AxisBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/BarChartTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/BarChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/CategoryAxisTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/CategoryAxisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/ChartBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/ChartBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/LineChartTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/LineChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/NumberAxisTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/NumberAxisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/PieChartTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/PieChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/StackedBarChartTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/StackedBarChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/ValueAxisBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/ValueAxisBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/chart/XYChartBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/chart/XYChartBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/choicebox/ChoiceTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/choicebox/ChoiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/colorpicker/ColorPickerTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/colorpicker/ColorPickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/colorpicker/TestBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/colorpicker/TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/combobox/ComboBoxTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/combobox/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/dialog/DialogTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/dialog/DialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/fxcanvas/FXCanvasBrowserTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/fxcanvas/FXCanvasBrowserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/fxcanvas/FXCanvasScrollTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/fxcanvas/FXCanvasScrollTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/fxcanvas/FXCanvasTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/fxcanvas/FXCanvasTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/jfxpanel/JFXPanelScrollTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/jfxpanel/JFXPanelScrollTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/jfxpanel/JFXPanelTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/jfxpanel/JFXPanelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/labeled/CheckBoxesTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/labeled/CheckBoxesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/labeled/HyperliksTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/labeled/HyperliksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/labeled/LabeledsBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/labeled/LabeledsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/labeled/LabelsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/labeled/LabelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/labeled/RadioButtonsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/labeled/RadioButtonsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/labeled/ToggleButtonsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/labeled/ToggleButtonsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/manual/ChooserManual.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/manual/ChooserManual.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/manual/MenuBarChildStage.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/manual/MenuBarChildStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/manual/MenuBarTwoInstancesAtOneStage.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/manual/MenuBarTwoInstancesAtOneStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/AccordionTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/AccordionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/ButtonsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/ButtonsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/ChecksTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/ChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuBarTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuBarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuButtonTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuItemTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuItemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/MenuTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/PopupMenuTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/PopupMenuTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/ProgressTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/ProgressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/ScrollBarTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/ScrollBarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/SeparatorsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/SeparatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/SliderTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/SliderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/SplitPaneTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/SplitPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/TitledPaneTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/TitledPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/TooltipTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/TooltipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mix/TreeViewTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mix/TreeViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart1Test.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart2Test.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart3Test.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart4Test.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/mixedpanes/ControlsLayoutPart4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/pagination/PaginationTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/pagination/PaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/richtexteditor/RichTextEditorTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/richtexteditor/RichTextEditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  */
 package javafx.scene.control.test.richtexteditor;

--- a/functional/ControlsTests/test/javafx/scene/control/test/scrollbar/ScrollBarTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/scrollbar/ScrollBarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/slider/SliderTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/slider/SliderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tableview/LayoutTableViewTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tableview/LayoutTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tableview/TableViewMultipleCellSelectionTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tableview/TableViewMultipleCellSelectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tableview/TableViewNewTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tableview/TableViewNewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tableview/TableViewTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tableview/TableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tabpane/NewTabPaneBase.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tabpane/NewTabPaneBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tabpane/NewTabPaneTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tabpane/NewTabPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tabpane/TabPane2Test.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tabpane/TabPane2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tabpane/TabPaneTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tabpane/TabPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/tabpane/TabTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/tabpane/TabTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/PasswordFieldTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/PasswordFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextAreaPropertiesTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextAreaPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextAreaTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextAreaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextAreaUndoRedoTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextAreaUndoRedoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextControlCommonTests.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextControlCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextFieldPropertiesTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextFieldPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextFieldTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/TextFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/textinput/UndoRedoBaseTests.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/textinput/UndoRedoBaseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/RadioButtonEventsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/RadioButtonEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/RadioButtonFreeTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/RadioButtonFreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/RadioButtonGroupedTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/RadioButtonGroupedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/ToggleButtonEventsTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/ToggleButtonEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/ToggleButtonFreeTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/ToggleButtonFreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/ToggleButtonGroupedTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/toggleradiobutton/ToggleButtonGroupedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/treetable/TreeTableAsTableTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/treetable/TreeTableAsTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/treetable/TreeTableAsTreeTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/treetable/TreeTableAsTreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/treetable/TreeTableMultipleSelectionTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/treetable/TreeTableMultipleSelectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/treeview/TreeViewOnlyTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/treeview/TreeViewOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/treeview/TreeViewTest.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/treeview/TreeViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/util/ClickableTrack.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/util/ClickableTrack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scene/control/test/util/TableListCommonTests.java
+++ b/functional/ControlsTests/test/javafx/scene/control/test/util/TableListCommonTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/ControlsTests/test/javafx/scrollEvent/ScrollEventTest.java
+++ b/functional/ControlsTests/test/javafx/scrollEvent/ScrollEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/FxmlTests/src/test/fxmltests/app/FxmlConstantApp.java
+++ b/functional/FxmlTests/src/test/fxmltests/app/FxmlConstantApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/FxmlTests/src/test/fxmltests/cover/FxmlCoverageDoclet.java
+++ b/functional/FxmlTests/src/test/fxmltests/cover/FxmlCoverageDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/FxmlTests/test/test/fxmltests/functional/ConstantsTest.java
+++ b/functional/FxmlTests/test/test/fxmltests/functional/ConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/FxmlTests/test/test/fxmltests/functional/MenuDefaultValueTest.java
+++ b/functional/FxmlTests/test/test/fxmltests/functional/MenuDefaultValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/FxmlTests/test/test/fxmltests/functional/NullBuilderFactoryTest.java
+++ b/functional/FxmlTests/test/test/fxmltests/functional/NullBuilderFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  */
 package test.fxmltests.functional;

--- a/functional/SceneGraphTests/src/test/scenegraph/app/ImagesApp.java
+++ b/functional/SceneGraphTests/src/test/scenegraph/app/ImagesApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  */
 package test.scenegraph.app;

--- a/functional/SceneGraphTests/test/test/scenegraph/functional/mix/SceneEventHandlersTest.java
+++ b/functional/SceneGraphTests/test/test/scenegraph/functional/mix/SceneEventHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  */
 package test.scenegraph.functional.mix;

--- a/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/FileGlassImageLoader.java
+++ b/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/FileGlassImageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/GlassImageLoader.java
+++ b/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/GlassImageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/GlassPixelImageComparator.java
+++ b/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/GlassPixelImageComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/PNGSaver.java
+++ b/tools/Jemmy/GlassImage/src/org/jemmy/image/glass/PNGSaver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/samples/org/jemmy/samples/treetableview/TreeTableViewApp.java
+++ b/tools/Jemmy/JemmyFX/samples/org/jemmy/samples/treetableview/TreeTableViewApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/samples/org/jemmy/samples/treeview/TreeViewApp.java
+++ b/tools/Jemmy/JemmyFX/samples/org/jemmy/samples/treeview/TreeViewApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/samples/org/jemmy/samples/treeview/TreeViewSample.java
+++ b/tools/Jemmy/JemmyFX/samples/org/jemmy/samples/treeview/TreeViewSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/control/Scrollable2DImpl.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/control/Scrollable2DImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 ,2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/control/TreeTableNodeWrap.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/control/TreeTableNodeWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/input/ScrollTrack.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/input/ScrollTrack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Close.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Close.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Closer.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Closer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/EditableCellOwner.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/EditableCellOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/List.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/List.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Scrollable2D.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Scrollable2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Shiftable.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Shiftable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Shifter.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Shifter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Table.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Table.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Tree.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/Tree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/TreeSelector.java
+++ b/tools/Jemmy/JemmyFX/src/org/jemmy/fx/interfaces/TreeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tools/Jemmy/JemmyFX/test/org/jemmy/fx/control/TreeTableViewTest.java
+++ b/tools/Jemmy/JemmyFX/test/org/jemmy/fx/control/TreeTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
As mentioned in the JBS Description, I generated this PR by running the same copyright tool we use to update the jfx repo, with a slight modification to not filter out those files that already had "Copyright.*2023", since those are the ones that need to be fixed up for incorrect formatting.

I manually reverted two files that had an embedded copyright line in a String.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315809](https://bugs.openjdk.org/browse/JDK-8315809): Fix copyright lines in jfx-tests repo after JDK-8315409 (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/2.diff">https://git.openjdk.org/jfx-tests/pull/2.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/2#issuecomment-1708890593)