### PR TITLE
8315845: Exclude Scenegraph and Charts test classes that serve as a base class

### DIFF
--- a/functional/ControlsTests/build.xml
+++ b/functional/ControlsTests/build.xml
@@ -3,6 +3,7 @@
     <basename file="${basedir}" property="."/>
     <property name="rootdir" location="${basedir}/../.."/>
     <property name="project.name" value="ControlsTests"/>
+    <property name="test.problem.list" location="test/ProblemList.txt"/>
     <import file="${basedir}/../../tools/make/build-template.xml"/> 
     <property name="dependencies.classpath" value="${jemmyfx-src}/build/classes${path.separator}${glass-robot-src}/build/classes${path.separator}${glass-image-src}/build/classes${path.separator}${jtreg.home}/lib/junit.jar${path.separator}${javafx.home}/lib/javafx-swt.jar${path.separator}${javafx.home}/lib/javafx.swing.jar${path.separator}${shared-test-utils-src}/build/classes${path.separator}${test-markup-src}/build/classes"/>
     <target name="build-dependencies">

--- a/functional/ControlsTests/test/ProblemList.txt
+++ b/functional/ControlsTests/test/ProblemList.txt
@@ -1,0 +1,4 @@
+javafx/scene/control/test/chart/AxisBase.java
+javafx/scene/control/test/chart/ChartBase.java
+javafx/scene/control/test/chart/ValueAxisBase.java
+javafx/scene/control/test/chart/XYChartBase.java

--- a/functional/SceneGraphTests/build.xml
+++ b/functional/SceneGraphTests/build.xml
@@ -3,6 +3,7 @@
     <basename file="${basedir}" property="."/>
     <property name="rootdir" location="${basedir}/../.."/>
     <property name="project.name" value="SceneGraphTests"/>
+    <property name="test.problem.list" location="test/ProblemList.txt"/>
     <import file="${basedir}/../../tools/make/build-template.xml"/> 
     <property name="dependencies.classpath" value="${jemmyfx-src}/build/classes${path.separator}${glass-robot-src}/build/classes${path.separator}${glass-image-src}/build/classes${path.separator}${jemmyfx-browser-src}/build/classes${path.separator}${jtreg.home}/lib/junit.jar${path.separator}${javafx.home}/lib/javafx-swt.jar${path.separator}${javafx.home}/lib/javafx.swing.jar${path.separator}${shared-test-utils-src}/build/classes"/>
     <target name="build-dependencies">

--- a/functional/SceneGraphTests/test/ProblemList.txt
+++ b/functional/SceneGraphTests/test/ProblemList.txt
@@ -1,0 +1,5 @@
+test/scenegraph/events/EventTestCommon.java
+test/scenegraph/events/EventTestHidingPopup.java
+test/scenegraph/events/EventTestTextInput.java
+test/scenegraph/richtext/RichTextPropertiesFunctional.java
+test/scenegraph/richtext/RichTextTestBase.java


### PR DESCRIPTION
A few SceneGraphTests and ControlsTests/chart test classes are abstract classes and serve as base classes for other tests.
They are excluded from test execution and hence result in avoiding false failure reports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315845](https://bugs.openjdk.org/browse/JDK-8315845): Exclude Scenegraph and Charts test classes that serve as a base class (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - Author)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/4.diff">https://git.openjdk.org/jfx-tests/pull/4.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/4#issuecomment-1709820303)