### PR TITLE
8315842: 3D tests fail because of edge pixel differences

### DIFF
--- a/functional/3DTests/src/test/scenegraph/fx3d/utils/FX3DAbstractApp.java
+++ b/functional/3DTests/src/test/scenegraph/fx3d/utils/FX3DAbstractApp.java
@@ -39,6 +39,7 @@ public abstract class FX3DAbstractApp extends Application {
 
     private static FX3DAbstractApp inst;
     private static boolean isTest = false;
+    public static final float COLOR_TOLERANCE = 0.05f;
     protected Stage stage;
 
     public void reinitScene() {

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeAsChildTest.java
@@ -44,7 +44,8 @@ public class PerspectiveCameraFixedEyeAsChildTest extends PerspectiveCameraFixed
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         PerspectiveCameraFixedEyeAsChildTestApp.main(null);
         app = (PerspectiveCameraFixedEyeAsChildTestApp) PerspectiveCameraFixedEyeAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeAsChildTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.camera.fixedeye;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraFixedEyeAsChildTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraFixedEyeAsChildTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class PerspectiveCameraFixedEyeAsChildTest extends PerspectiveCameraFixed
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         PerspectiveCameraFixedEyeAsChildTestApp.main(null);
         app = (PerspectiveCameraFixedEyeAsChildTestApp) PerspectiveCameraFixedEyeAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeIsolateTest.java
@@ -44,7 +44,8 @@ public class PerspectiveCameraFixedEyeIsolateTest extends PerspectiveCameraFixed
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         PerspectiveCameraFixedEyeIsolateTestApp.main(null);
         app = (PerspectiveCameraFixedEyeIsolateTestApp) PerspectiveCameraFixedEyeIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeIsolateTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.camera.fixedeye;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraFixedEyeIsolateTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraFixedEyeIsolateTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class PerspectiveCameraFixedEyeIsolateTest extends PerspectiveCameraFixed
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         PerspectiveCameraFixedEyeIsolateTestApp.main(null);
         app = (PerspectiveCameraFixedEyeIsolateTestApp) PerspectiveCameraFixedEyeIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraAsChildTest.java
@@ -44,7 +44,8 @@ public class ParallelCameraAsChildTest extends CameraAsChildTests {
     @BeforeClass
     public static void setUp(){
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         ParallelCameraAsChildTestApp.main(null);
         app = (ParallelCameraAsChildTestApp) ParallelCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraAsChildTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.camera.parallel;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.CameraAsChildTests;
 import test.scenegraph.fx3d.interfaces.camera.CameraAsChildTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class ParallelCameraAsChildTest extends CameraAsChildTests {
 
     @BeforeClass
     public static void setUp(){
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         ParallelCameraAsChildTestApp.main(null);
         app = (ParallelCameraAsChildTestApp) ParallelCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraIsolateTest.java
@@ -44,7 +44,8 @@ public class ParallelCameraIsolateTest extends CameraIsolateTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         ParallelCameraIsolateTestApp.main(null);
         app = (ParallelCameraIsolateTestApp) ParallelCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/parallel/ParallelCameraIsolateTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.camera.parallel;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.CameraIsolateTests;
 import test.scenegraph.fx3d.interfaces.camera.CameraIsolateTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class ParallelCameraIsolateTest extends CameraIsolateTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         ParallelCameraIsolateTestApp.main(null);
         app = (ParallelCameraIsolateTestApp) ParallelCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraAsChildTest.java
@@ -44,7 +44,8 @@ public class PerspectiveCameraAsChildTest extends PerspectiveCameraAsChildTests{
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         PerspectiveCameraAsChildTestApp.main(null);
         app = (PerspectiveCameraAsChildTestApp)PerspectiveCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraAsChildTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.camera.perspective;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraAsChildTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraAsChildTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class PerspectiveCameraAsChildTest extends PerspectiveCameraAsChildTests{
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         PerspectiveCameraAsChildTestApp.main(null);
         app = (PerspectiveCameraAsChildTestApp)PerspectiveCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraIsolateTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.camera.perspective;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraIsolateTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraIsolateTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class PerspectiveCameraIsolateTest extends PerspectiveCameraIsolateTests 
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         PerspectiveCameraIsolateTestApp.main(null);
         app = (PerspectiveCameraIsolateTestApp) PerspectiveCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraIsolateTest.java
@@ -44,7 +44,8 @@ public class PerspectiveCameraIsolateTest extends PerspectiveCameraIsolateTests 
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         PerspectiveCameraIsolateTestApp.main(null);
         app = (PerspectiveCameraIsolateTestApp) PerspectiveCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/depth/DepthTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/depth/DepthTest.java
@@ -26,6 +26,10 @@ package test.scenegraph.fx3d.depth;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.depth.DepthTestApp.Pages;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
 
@@ -39,6 +43,8 @@ public class DepthTest extends DepthTestBase {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         DepthTestApp.setTest(true);
         DepthTestApp.main(null);
         application = (DepthTestApp) DepthTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/depth/DepthTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/depth/DepthTest.java
@@ -44,7 +44,8 @@ public class DepthTest extends DepthTestBase {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         DepthTestApp.setTest(true);
         DepthTestApp.main(null);
         application = (DepthTestApp) DepthTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/depth/IntersectionTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/depth/IntersectionTest.java
@@ -44,7 +44,8 @@ public class IntersectionTest extends DepthTestBase {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         IntersectionTestApp.setTest(true);
         IntersectionTestApp.main(null);
         application = (IntersectionTestApp) IntersectionTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/depth/IntersectionTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/depth/IntersectionTest.java
@@ -26,6 +26,10 @@ package test.scenegraph.fx3d.depth;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.depth.IntersectionTestApp.Pages;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
 
@@ -39,6 +43,8 @@ public class IntersectionTest extends DepthTestBase {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         IntersectionTestApp.setTest(true);
         IntersectionTestApp.main(null);
         application = (IntersectionTestApp) IntersectionTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/lighting/MultipleLightingTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/lighting/MultipleLightingTest.java
@@ -27,6 +27,9 @@ package test.scenegraph.fx3d.lighting;
 import javafx.scene.paint.Color;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -43,6 +46,8 @@ public class MultipleLightingTest extends FX3DTestBase {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         MultipleLightingTestApp.setTest(true);
         MultipleLightingTestApp.main(null);
         application = (MultipleLightingTestApp) MultipleLightingTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/lighting/MultipleLightingTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/lighting/MultipleLightingTest.java
@@ -47,7 +47,8 @@ public class MultipleLightingTest extends FX3DTestBase {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         MultipleLightingTestApp.setTest(true);
         MultipleLightingTestApp.main(null);
         application = (MultipleLightingTestApp) MultipleLightingTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/lighting/SingleLightingTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/lighting/SingleLightingTest.java
@@ -28,6 +28,9 @@ import javafx.scene.paint.Color;
 import junit.framework.Assert;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -44,6 +47,8 @@ public class SingleLightingTest extends FX3DTestBase {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SingleLightingTestApp.setTest(true);
         SingleLightingTestApp.main(null);
         application = (SingleLightingTestApp) SingleLightingTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/lighting/SingleLightingTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/lighting/SingleLightingTest.java
@@ -48,7 +48,8 @@ public class SingleLightingTest extends FX3DTestBase {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SingleLightingTestApp.setTest(true);
         SingleLightingTestApp.main(null);
         application = (SingleLightingTestApp) SingleLightingTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/BoxTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/BoxTest.java
@@ -27,6 +27,9 @@ package test.scenegraph.fx3d.shapes;
 import javafx.util.Pair;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -42,6 +45,8 @@ public class BoxTest extends BoxTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         BoxTestApp.main(null);
         application = (BoxTestApp) BoxTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/BoxTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/BoxTest.java
@@ -46,7 +46,8 @@ public class BoxTest extends BoxTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         BoxTestApp.main(null);
         application = (BoxTestApp) BoxTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/CylinderTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/CylinderTest.java
@@ -27,6 +27,9 @@ package test.scenegraph.fx3d.shapes;
 import javafx.util.Pair;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -94,6 +97,8 @@ public class CylinderTest extends CylinderTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         CylinderTestApp.main(null);
         application = (CylinderTestApp) CylinderTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/CylinderTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/CylinderTest.java
@@ -98,7 +98,8 @@ public class CylinderTest extends CylinderTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         CylinderTestApp.main(null);
         application = (CylinderTestApp) CylinderTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/MeshTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/MeshTest.java
@@ -57,7 +57,8 @@ public class MeshTest extends MeshTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         MeshTestApp.setTest(true);
         MeshTestApp.main(null);
         meshApplication = (MeshTestApp) MeshTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/MeshTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/MeshTest.java
@@ -28,6 +28,9 @@ import javafx.util.Pair;
 import junit.framework.Assert;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -53,6 +56,8 @@ public class MeshTest extends MeshTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         MeshTestApp.setTest(true);
         MeshTestApp.main(null);
         meshApplication = (MeshTestApp) MeshTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/SphereTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/SphereTest.java
@@ -27,6 +27,9 @@ package test.scenegraph.fx3d.shapes;
 import javafx.util.Pair;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -84,6 +87,8 @@ public class SphereTest extends SphereTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SphereTestApp.main(null);
         application = (SphereTestApp) SphereTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/shapes/SphereTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/shapes/SphereTest.java
@@ -88,7 +88,8 @@ public class SphereTest extends SphereTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SphereTestApp.main(null);
         application = (SphereTestApp) SphereTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/SubSceneBasicPropsTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/SubSceneBasicPropsTest.java
@@ -54,7 +54,8 @@ public class SubSceneBasicPropsTest extends FX3DTestBase {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneBasicPropsTestApp.setTest(true);
         SubSceneBasicPropsTestApp.main(null);
         application = (SubSceneBasicPropsTestApp) SubSceneBasicPropsTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/SubSceneBasicPropsTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/SubSceneBasicPropsTest.java
@@ -29,6 +29,9 @@ import javafx.scene.paint.Color;
 import javafx.scene.transform.Rotate;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,6 +53,8 @@ public class SubSceneBasicPropsTest extends FX3DTestBase {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneBasicPropsTestApp.setTest(true);
         SubSceneBasicPropsTestApp.main(null);
         application = (SubSceneBasicPropsTestApp) SubSceneBasicPropsTestApp.getInstance();

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeAsChildTest.java
@@ -44,7 +44,8 @@ public class SubScenePerspectiveCameraFixedEyeAsChildTest extends PerspectiveCam
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubScenePerspectiveCameraFixedEyeAsChildTestApp.main(null);
         app = (SubScenePerspectiveCameraFixedEyeAsChildTestApp) SubScenePerspectiveCameraFixedEyeAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeAsChildTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.subscene.camera.fixedeye;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraFixedEyeAsChildTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraFixedEyeAsChildTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class SubScenePerspectiveCameraFixedEyeAsChildTest extends PerspectiveCam
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubScenePerspectiveCameraFixedEyeAsChildTestApp.main(null);
         app = (SubScenePerspectiveCameraFixedEyeAsChildTestApp) SubScenePerspectiveCameraFixedEyeAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeIsolateTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.subscene.camera.fixedeye;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraFixedEyeIsolateTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraFixedEyeIsolateTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class SubScenePerspectiveCameraFixedEyeIsolateTest  extends PerspectiveCa
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubScenePerspectiveCameraFixedEyeIsolateTestApp.main(null);
         app = (SubScenePerspectiveCameraFixedEyeIsolateTestApp) SubScenePerspectiveCameraFixedEyeIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/fixedeye/SubScenePerspectiveCameraFixedEyeIsolateTest.java
@@ -44,7 +44,8 @@ public class SubScenePerspectiveCameraFixedEyeIsolateTest  extends PerspectiveCa
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubScenePerspectiveCameraFixedEyeIsolateTestApp.main(null);
         app = (SubScenePerspectiveCameraFixedEyeIsolateTestApp) SubScenePerspectiveCameraFixedEyeIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraAsChildTest.java
@@ -44,7 +44,8 @@ public class SubSceneParallelCameraAsChildTest extends CameraAsChildTests {
     @BeforeClass
     public static void setUp(){
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneParallelCameraAsChildTestApp.main(null);
         app = (SubSceneParallelCameraAsChildTestApp) SubSceneParallelCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraAsChildTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.subscene.camera.parallel;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.CameraAsChildTests;
 import test.scenegraph.fx3d.interfaces.camera.CameraAsChildTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class SubSceneParallelCameraAsChildTest extends CameraAsChildTests {
 
     @BeforeClass
     public static void setUp(){
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneParallelCameraAsChildTestApp.main(null);
         app = (SubSceneParallelCameraAsChildTestApp) SubSceneParallelCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraIsolateTest.java
@@ -44,7 +44,8 @@ public class SubSceneParallelCameraIsolateTest extends CameraIsolateTests{
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneParallelCameraIsolateTestApp.main(null);
         app = (SubSceneParallelCameraIsolateTestApp) SubSceneParallelCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/parallel/SubSceneParallelCameraIsolateTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.subscene.camera.parallel;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.CameraIsolateTests;
 import test.scenegraph.fx3d.interfaces.camera.CameraIsolateTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class SubSceneParallelCameraIsolateTest extends CameraIsolateTests{
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneParallelCameraIsolateTestApp.main(null);
         app = (SubSceneParallelCameraIsolateTestApp) SubSceneParallelCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraAsChildTest.java
@@ -44,7 +44,8 @@ public class SubScenePerspectiveCameraAsChildTest extends PerspectiveCameraAsChi
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubScenePerspectiveCameraAsChildTestApp.main(null);
         app = (SubScenePerspectiveCameraAsChildTestApp) SubScenePerspectiveCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraAsChildTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraAsChildTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.subscene.camera.perspective;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraAsChildTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraAsChildTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class SubScenePerspectiveCameraAsChildTest extends PerspectiveCameraAsChi
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubScenePerspectiveCameraAsChildTestApp.main(null);
         app = (SubScenePerspectiveCameraAsChildTestApp) SubScenePerspectiveCameraAsChildTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraIsolateTest.java
@@ -44,7 +44,8 @@ public class SubScenePerspectiveCameraIsolateTest extends PerspectiveCameraIsola
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubScenePerspectiveCameraIsolateTestApp.main(null);
         app = (SubScenePerspectiveCameraIsolateTestApp) SubScenePerspectiveCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraIsolateTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/camera/perspective/SubScenePerspectiveCameraIsolateTest.java
@@ -25,6 +25,10 @@
 package test.scenegraph.fx3d.subscene.camera.perspective;
 
 import org.junit.BeforeClass;
+import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.camera.PerspectiveCameraIsolateTests;
 import test.scenegraph.fx3d.interfaces.camera.PerspectiveCameraIsolateTestingFace;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -39,6 +43,8 @@ public class SubScenePerspectiveCameraIsolateTest extends PerspectiveCameraIsola
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubScenePerspectiveCameraIsolateTestApp.main(null);
         app = (SubScenePerspectiveCameraIsolateTestApp) SubScenePerspectiveCameraIsolateTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/lighting/scoping/SubSceneLightScopingTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/lighting/scoping/SubSceneLightScopingTest.java
@@ -54,7 +54,8 @@ public class SubSceneLightScopingTest extends FX3DTestBase {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneLightScopingTestApp.main(null);
         application = (SubSceneLightScopingTestApp) SubSceneLightScopingTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/lighting/scoping/SubSceneLightScopingTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/lighting/scoping/SubSceneLightScopingTest.java
@@ -28,6 +28,9 @@ import javafx.scene.Node;
 import javafx.scene.paint.Color;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -50,6 +53,8 @@ public class SubSceneLightScopingTest extends FX3DTestBase {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneLightScopingTestApp.main(null);
         application = (SubSceneLightScopingTestApp) SubSceneLightScopingTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneBoxTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneBoxTest.java
@@ -47,7 +47,8 @@ public class SubSceneBoxTest extends BoxTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneBoxTestApp.main(null);
         application = (SubSceneBoxTestApp) SubSceneBoxTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneBoxTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneBoxTest.java
@@ -28,6 +28,9 @@ import javafx.util.Pair;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
 import org.junit.BeforeClass;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.shapes.BoxTests;
 import test.scenegraph.fx3d.utils.FX3DAbstractApp;
@@ -43,6 +46,8 @@ public class SubSceneBoxTest extends BoxTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneBoxTestApp.main(null);
         application = (SubSceneBoxTestApp) SubSceneBoxTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneCylinderTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneCylinderTest.java
@@ -98,7 +98,8 @@ public class SubSceneCylinderTest extends CylinderTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneCylinderTestApp.main(null);
         application = (SubSceneCylinderTestApp) SubSceneCylinderTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneCylinderTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneCylinderTest.java
@@ -27,6 +27,9 @@ package test.scenegraph.fx3d.subscene.shapes;
 import javafx.util.Pair;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.shapes.CylinderTests;
@@ -94,6 +97,8 @@ public class SubSceneCylinderTest extends CylinderTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneCylinderTestApp.main(null);
         application = (SubSceneCylinderTestApp) SubSceneCylinderTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneMeshTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneMeshTest.java
@@ -58,7 +58,8 @@ public class SubSceneMeshTest extends MeshTests {
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneMeshTestApp.main(null);
         application = (SubSceneMeshTestApp) SubSceneMeshTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneMeshTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneMeshTest.java
@@ -28,6 +28,9 @@ import javafx.util.Pair;
 import junit.framework.Assert;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.shapes.MeshTests;
@@ -54,6 +57,8 @@ public class SubSceneMeshTest extends MeshTests {
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneMeshTestApp.main(null);
         application = (SubSceneMeshTestApp) SubSceneMeshTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneSphereTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneSphereTest.java
@@ -27,6 +27,9 @@ package test.scenegraph.fx3d.subscene.shapes;
 import javafx.util.Pair;
 import org.jemmy.action.GetAction;
 import org.jemmy.fx.Root;
+import org.jemmy.image.ImageComparator;
+import org.jemmy.image.glass.GlassPixelImageComparator;
+import org.jemmy.image.pixel.PixelEqualityRasterComparator;
 import org.junit.BeforeClass;
 import test.scenegraph.fx3d.interfaces.ShapesTestingFace;
 import test.scenegraph.fx3d.shapes.SphereTests;
@@ -83,6 +86,8 @@ private static SubSceneSphereTestApp application;
 
     @BeforeClass
     public static void setUp() {
+        Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
+            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
         SubSceneSphereTestApp.main(null);
         application = (SubSceneSphereTestApp) SubSceneSphereTestApp.getInstance();
     }

--- a/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneSphereTest.java
+++ b/functional/3DTests/test/test/scenegraph/fx3d/subscene/shapes/SubSceneSphereTest.java
@@ -87,7 +87,8 @@ private static SubSceneSphereTestApp application;
     @BeforeClass
     public static void setUp() {
         Root.ROOT.getEnvironment().setProperty(ImageComparator.class,
-            new GlassPixelImageComparator(new PixelEqualityRasterComparator(.05)));
+            new GlassPixelImageComparator(new
+                PixelEqualityRasterComparator(FX3DAbstractApp.COLOR_TOLERANCE)));
         SubSceneSphereTestApp.main(null);
         application = (SubSceneSphereTestApp) SubSceneSphereTestApp.getInstance();
     }


### PR DESCRIPTION
Out of 62 3D tests, 26 tests fail because of minute color differences in edge pixels.
These tests are used to verify 3D rendering with different parameters like translation, rotation.

So adding little color tolerance will not change the test behavior and allows us to use these tests to automatically verify any regression introduced in 3D rendering.

Added 5% color tolerance and with this change 23 of these tests pass.

Some sub-tests under below 3 tests continue to fail because of other reasons:
[test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeIsolateTest.java](file:///Users/jdv/dev/workspace/jfx/jfx-tests/functional/3DTests/build/test.workdir/test/scenegraph/fx3d/camera/fixedeye/PerspectiveCameraFixedEyeIsolateTest.jtr)
[test/scenegraph/fx3d/camera/parallel/ParallelCameraIsolateTest.java](file:///Users/jdv/dev/workspace/jfx/jfx-tests/functional/3DTests/build/test.workdir/test/scenegraph/fx3d/camera/parallel/ParallelCameraIsolateTest.jtr)
[test/scenegraph/fx3d/camera/perspective/PerspectiveCameraIsolateTest.java](file:///Users/jdv/dev/workspace/jfx/jfx-tests/functional/3DTests/build/test.workdir/test/scenegraph/fx3d/camera/perspective/PerspectiveCameraIsolateTest.jtr)

Also i see that some of the camera tests just draw white images, this also needs to be verified.
With this change 41 out of 62 3D tests will run properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315842](https://bugs.openjdk.org/browse/JDK-8315842): 3D tests fail because of edge pixel differences (**Bug** - P3)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/5.diff">https://git.openjdk.org/jfx-tests/pull/5.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/5#issuecomment-1709899302)