### PR TITLE
JDK-8315895: Some 3D camera tests fail because of NPE

### DIFF
--- a/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraAbstractApp.java
+++ b/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraAbstractApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraAbstractApp.java
+++ b/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraAbstractApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraIsolateAbstractApp.java
+++ b/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraIsolateAbstractApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraIsolateAbstractApp.java
+++ b/functional/3DTests/src/test/scenegraph/fx3d/camera/CameraIsolateAbstractApp.java
@@ -38,8 +38,6 @@ import test.scenegraph.fx3d.interfaces.camera.CameraIsolateTestingFace;
  */
 public abstract class CameraIsolateAbstractApp extends CameraAbstractApp implements CameraIsolateTestingFace{
 
-    protected Camera camera;
-
     @Override
     protected void initCamera() {
         camera = addCamera(scene);


### PR DESCRIPTION
There was a field in a subclass hiding a field in a superclass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315895](https://bugs.openjdk.org/browse/JDK-8315895): Some 3D camera tests fail because of NPE (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/8.diff">https://git.openjdk.org/jfx-tests/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/8#issuecomment-1711986042)