### PR TITLE
8316097: Some Scenegraph/richtext tests fail due to IllegalStateException

### DIFF
--- a/functional/SceneGraphTests/src/test/scenegraph/richtext/RichTextPropertiesApp.java
+++ b/functional/SceneGraphTests/src/test/scenegraph/richtext/RichTextPropertiesApp.java
@@ -246,14 +246,8 @@ public class RichTextPropertiesApp extends InteroperabilityApp {
     }
 
     public void requestDefaultFocus(){
-
-        PlatformImpl.runAndWait(new Runnable() {
-            @Override
-            public void run() {
-                textFlowPage.addTextFlow.requestFocus();
-            }
-        });
-   }
+       PlatformImpl.runAndWait(() -> textFlowPage.addTextFlow.requestFocus());
+    }
 
     private class TextFlowPage extends VBox {
 

--- a/functional/SceneGraphTests/src/test/scenegraph/richtext/RichTextPropertiesApp.java
+++ b/functional/SceneGraphTests/src/test/scenegraph/richtext/RichTextPropertiesApp.java
@@ -39,6 +39,8 @@ import javafx.scene.text.TextFlow;
 import junit.framework.Assert;
 import test.javaclient.shared.InteroperabilityApp;
 import test.javaclient.shared.Utils;
+import com.sun.javafx.application.PlatformImpl;
+
 
 /**
  *
@@ -242,9 +244,16 @@ public class RichTextPropertiesApp extends InteroperabilityApp {
     public void addFlow() {
         textFlowPage.addTextFlow.fire();
     }
+
     public void requestDefaultFocus(){
-        textFlowPage.addTextFlow.requestFocus();
-    }
+
+        PlatformImpl.runAndWait(new Runnable() {
+            @Override
+            public void run() {
+                textFlowPage.addTextFlow.requestFocus();
+            }
+        });
+   }
 
     private class TextFlowPage extends VBox {
 

--- a/functional/SceneGraphTests/src/test/scenegraph/richtext/RichTextSpecSymbApp.java
+++ b/functional/SceneGraphTests/src/test/scenegraph/richtext/RichTextSpecSymbApp.java
@@ -76,8 +76,10 @@ public class RichTextSpecSymbApp extends InteroperabilityApp {
             @Override
             public String toString(char[] t) {
                 String result = "";
-                for (char sim : t) {
-                    result += "<" + sim + "> ";
+                if (t != null) {
+                    for (char sim : t) {
+                        result += "<" + sim + "> ";
+                    }
                 }
                 return result;
             }


### PR DESCRIPTION
test/scenegraph/richtext/RichTextLabeledsTest.java
test/scenegraph/richtext/RichTextMixedTest.java
test/scenegraph/richtext/RichTextRectangleTest.java
test/scenegraph/richtext/RichTextTextTest.java

These tests were failing with -  java.lang.IllegalStateException: This operation is permitted on the event thread only; currentThread = Time-limited test. They are fixed with a change to single file `RichTextPropertiesApp.java`

Another test - test/scenegraph/richtext/RichTextSpecSymbTest.java - was failing due to NPE. Added a null check to fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316097](https://bugs.openjdk.org/browse/JDK-8316097): Some Scenegraph/richtext tests fail due to IllegalStateException (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/9.diff">https://git.openjdk.org/jfx-tests/pull/9.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/9#issuecomment-1715478619)