### PR TITLE
8316116: Ignore a single failing test case from Effects2Test

### DIFF
--- a/functional/SceneGraphTests/test/test/scenegraph/functional/graphics/Effects2Test.java
+++ b/functional/SceneGraphTests/test/test/scenegraph/functional/graphics/Effects2Test.java
@@ -24,6 +24,7 @@
 package test.scenegraph.functional.graphics;
 
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.BeforeClass;
 
 import test.javaclient.shared.TestBase;
@@ -771,6 +772,7 @@ public class Effects2Test extends TestBase {
  * test javafx.scene.effect.Lighting
  * with setLight(new SpotLight() {{setX(70);setY(120);setZ(50);setPointsAtX(150);setPointsAtY(0);setPointsAtZ(0);
  */
+    @Ignore("JDK-8316117")
     @Test
     public void Lightningspotlight() throws InterruptedException {
         testCommon(Pages.Lightning.name(),"spot light");


### PR DESCRIPTION
test/scenegraph/functional/graphics/Effects2Test.java has a total of 123 test cases. Out of which 122 test cases pass and 1 test case (Lightningspotlight) fails consistently. Right now, the root cause of this test failure is unknown.

This PR marks this test case with `@Ignore`. It will be fixed in future under [JDK-8316117](https://bugs.openjdk.org/browse/JDK-8316117).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316116](https://bugs.openjdk.org/browse/JDK-8316116): Ignore a single failing test case from Effects2Test (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/10.diff">https://git.openjdk.org/jfx-tests/pull/10.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/10#issuecomment-1715870341)