### PR TITLE
8316490: Problemlist ParallelCamera picking tests

### DIFF
--- a/functional/3DTests/build.xml
+++ b/functional/3DTests/build.xml
@@ -3,7 +3,7 @@
     <basename file="${basedir}" property="."/>
     <property name="rootdir" location="${basedir}/../.."/>
     <property name="project.name" value="3DTests"/>
-    <!--property name="test.problem.list" location="test/ProblemList.txt"/-->
+    <property name="test.problem.list" location="test/ProblemList.txt"/>
     <import file="${basedir}/../../tools/make/build-template.xml"/> 
     <property name="dependencies.classpath" value="${jemmyfx-src}/build/classes${path.separator}${glass-robot-src}/build/classes${path.separator}${glass-image-src}/build/classes${path.separator}${jemmyfx-browser-src}/build/classes${path.separator}${jtreg.home}/lib/junit.jar${path.separator}${javafx.home}/lib/javafx-swt.jar${path.separator}${javafx.home}/lib/javafx.swing.jar${path.separator}${shared-test-utils-src}/build/classes"/>
     <target name="build-dependencies">

--- a/functional/3DTests/test/ProblemList.txt
+++ b/functional/3DTests/test/ProblemList.txt
@@ -1,1 +1,9 @@
 #test/scenegraph/fx3d/lighting/SingleLightingTest.java <bug_id> generic-all
+test/scenegraph/fx3d/picking/parallel/MeshCameraParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/picking/parallel/MeshGroupParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/picking/parallel/ShapesCameraParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/picking/parallel/ShapesGroupParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/subscene/picking/parallel/SubSceneMeshCameraParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/subscene/picking/parallel/SubSceneMeshGroupParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/subscene/picking/parallel/SubSceneShapeCameraParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/subscene/picking/parallel/SubSceneShapeGroupParallelPickingTest.java 8165941 generic-all


### PR DESCRIPTION
When we run 3D picking tests under test/scenegraph/fx3d/picking/parallel/ nothing is displayed on the window and subscene parallel camera tests under test/scenegraph/fx3d/subscene/picking/parallel/ throw UnsupportedOperationException.

Subscene parallel camera tests are incomplete and even if we update the tests nothing will be shown because of product issue https://bugs.openjdk.org/browse/JDK-8165941.

ParallelCamera forces near and far clip to be between -viewWidthOrHeight/2 and viewWidthOrHeight/2. So in these test cases we generate a mesh and then scale it 100x. After that we move camera to large -z position to make content visible. This causes content to move into clipping area in case of ParallelCamera. Until https://bugs.openjdk.org/browse/JDK-8165941 is fixed we should problemlist these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316490](https://bugs.openjdk.org/browse/JDK-8316490): Problemlist ParallelCamera picking tests (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/12.diff">https://git.openjdk.org/jfx-tests/pull/12.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/12#issuecomment-1731131473)