### PR TITLE
8316807: Exclude 3D subscene perspective camera picking tests

### DIFF
--- a/functional/3DTests/test/ProblemList.txt
+++ b/functional/3DTests/test/ProblemList.txt
@@ -7,3 +7,11 @@ test/scenegraph/fx3d/subscene/picking/parallel/SubSceneMeshCameraParallelPicking
 test/scenegraph/fx3d/subscene/picking/parallel/SubSceneMeshGroupParallelPickingTest.java 8165941 generic-all
 test/scenegraph/fx3d/subscene/picking/parallel/SubSceneShapeCameraParallelPickingTest.java 8165941 generic-all
 test/scenegraph/fx3d/subscene/picking/parallel/SubSceneShapeGroupParallelPickingTest.java 8165941 generic-all
+test/scenegraph/fx3d/subscene/picking/fixedeye/SubSceneMeshCameraFixedEyePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/fixedeye/SubSceneMeshGroupFixedEyePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/fixedeye/SubSceneShapesCameraFixedEyePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/fixedeye/SubSceneShapesGroupFixedEyePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/perspective/SubSceneMeshCameraPerspectivePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/perspective/SubSceneMeshGroupPerspectivePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/perspective/SubSceneShapesCameraPerspectivePickingTest.java 8317309 generic-all
+test/scenegraph/fx3d/subscene/picking/perspective/SubSceneShapesGroupPerspectivePickingTest.java 8317309 generic-all


### PR DESCRIPTION
While debugging subscene picking tests it was identified that in subscene mouse events are not captured when we click on area where nothing is drawn or filled.
All the picking tests actually click on these null points and expect a mouse event. This causes TimeoutExpiredException when subscene is used.

Also we add borders to subscene and expect it to return same pickresults as in scene.
Removed borders for subscene and also added mouse event handler on scene itself. Adding mouse event handler on scene resolves TimeoutExpiredException but still the subscene tests continue to fail.

Currently we are trying to stabilize as many tests as possible to use these automated tests for Metal pipeline implementation. To continue more investigation regarding these failures i have created : https://bugs.openjdk.org/browse/JDK-8317309 and to update subscene specification for difference in how mouse event are handled i have created : https://bugs.openjdk.org/browse/JDK-8317310

We should problem list these tests and continue debugging as part of separate bug : https://bugs.openjdk.org/browse/JDK-8317309

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316807](https://bugs.openjdk.org/browse/JDK-8316807): Exclude 3D subscene perspective camera picking tests (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx-tests.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jfx-tests.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx-tests/pull/13.diff">https://git.openjdk.org/jfx-tests/pull/13.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx-tests/pull/13#issuecomment-1740722885)